### PR TITLE
GOOG-37 - Fix wrong SERVERITY log level when executing via docker

### DIFF
--- a/gcp_variant_transforms/bq_to_vcf.py
+++ b/gcp_variant_transforms/bq_to_vcf.py
@@ -69,6 +69,8 @@ from gcp_variant_transforms.transforms import combine_sample_ids
 from gcp_variant_transforms.transforms import densify_variants
 from gcp_variant_transforms.transforms import sample_mapping_table
 
+from gcp_variant_transforms import helper
+helper.setup_logging()
 
 
 _BASE_QUERY_TEMPLATE = 'SELECT {COLUMNS} FROM `{INPUT_TABLE}`'

--- a/gcp_variant_transforms/helper.py
+++ b/gcp_variant_transforms/helper.py
@@ -1,0 +1,23 @@
+#!/bin/python3
+
+import logging
+import sys
+import json
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        return json.dumps({
+            "severity": record.levelname,
+            "message": record.getMessage(),
+            "logger": record.name,
+            "module": record.module,
+            "lineno": record.lineno
+        })
+
+def setup_logging(level=logging.INFO):
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+
+    logger = logging.getLogger()
+    logger.setLevel(level)
+    logger.handlers = [handler]

--- a/gcp_variant_transforms/libs/bigquery_util.py
+++ b/gcp_variant_transforms/libs/bigquery_util.py
@@ -34,7 +34,7 @@ _VcfHeaderTypeConstants = vcf_header_io.VcfHeaderFieldTypeConstants
 TABLE_SUFFIX_SEPARATOR = '__'
 
 _BQ_DELETE_TABLE_COMMAND = 'bq rm -f -t {FULL_TABLE_ID}'
-_GCS_DELETE_FILES_COMMAND = 'gsutil -m rm -f -R {ROOT_PATH}'
+_GCS_DELETE_FILES_COMMAND = 'gsutil -m rm -f -R {ROOT_PATH} 2>&1'
 BQ_NUM_RETRIES = 5
 
 

--- a/gcp_variant_transforms/options/variant_transform_options.py
+++ b/gcp_variant_transforms/options/variant_transform_options.py
@@ -370,7 +370,7 @@ class AnnotationOptions(VariantTransformsOptions):
               'process of running VEP pipelines.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_IMAGE_FLAG,
-        default='gcr.io/cloud-lifesciences/vep:104', # TODO: Change Docker URI to Google hosted one
+        default='gcr.io/cloud-lifesciences/vep:104', # TODO: The Docker image must be rebuilt and hosted elsewhere
         help=('The URI of the latest docker image for VEP.'))
     parser.add_argument(
         '--' + AnnotationOptions._VEP_CACHE_FLAG,

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -78,6 +78,9 @@ from gcp_variant_transforms.transforms import shard_variants
 from gcp_variant_transforms.transforms import variant_to_avro
 from gcp_variant_transforms.transforms import write_variants_to_shards
 
+from gcp_variant_transforms import helper
+helper.setup_logging()
+
 _COMMAND_LINE_OPTIONS = [
     variant_transform_options.VcfReadOptions,
     variant_transform_options.BigQueryWriteOptions,

--- a/gcp_variant_transforms/vcf_to_bq.py
+++ b/gcp_variant_transforms/vcf_to_bq.py
@@ -477,9 +477,9 @@ def decompress_gz_files(input_pattern: str, region: str) -> List[str]:
 
             command = f"""
             set -e &&
-            gsutil cp {get_gsuri(blob)} {local_gz_path} &&
-            gunzip -c {local_gz_path} > {local_decompressed_path} &&
-            gsutil cp {local_decompressed_path} {get_gsuri(bucket.blob(destination_blob_name))} &&
+            gsutil cp {get_gsuri(blob)} {local_gz_path} 2>&1 &&
+            gunzip -c {local_gz_path} > {local_decompressed_path} 2>&1 &&
+            gsutil cp {local_decompressed_path} {get_gsuri(bucket.blob(destination_blob_name))} 2>&1 &&
             echo "Decompressed {blob.name} to {destination_blob_name}"
             """
             runnable = Runnable(
@@ -817,7 +817,7 @@ def run(argv=None):
                  avro_root_path)
     raise e
   else:
-    logging.warning('All AVRO files were successfully loaded to BigQuery.')
+    logging.info('All AVRO files were successfully loaded to BigQuery.')
     if known_args.keep_intermediate_avro_files:
       logging.info('Since "--keep_intermediate_avro_files" flag is set, the '
                    'AVRO files are kept and stored at: %s', avro_root_path)

--- a/gcp_variant_transforms/vcf_to_bq_preprocess.py
+++ b/gcp_variant_transforms/vcf_to_bq_preprocess.py
@@ -62,6 +62,9 @@ from gcp_variant_transforms.transforms import infer_headers
 from gcp_variant_transforms.transforms import merge_headers
 from gcp_variant_transforms.transforms import merge_header_definitions
 
+from gcp_variant_transforms import helper
+helper.setup_logging()
+
 _COMMAND_LINE_OPTIONS = [variant_transform_options.PreprocessOptions]
 
 


### PR DESCRIPTION
- Added log structure
- Redirected CLI stderr to stdout using 2>&1

=> Test full pipeline: [Batch job run with docker](https://console.cloud.google.com/batch/jobsDetail/regions/us-central1/jobs/vcf-to-bq-20250804043536/logs?inv=1&invt=Ab4jOw&orgonly=true&project=variant-transform-dxt&supportedpurview=organizationId)